### PR TITLE
CSW-274: redo logic for displaying PDFs and "open PDF in new window" …

### DIFF
--- a/extras/application_helper.rb
+++ b/extras/application_helper.rb
@@ -46,18 +46,21 @@ module ApplicationHelper
   end
 
   def check_pdf options = {}
-    # render a pdf using html5 pdf viewer
+    # access_code is set by CSpace value in publisher authority record
     access_code = options[:document][:code_s]
+    # access_code==4 => "World"
     if access_code == '4'
-      render_pdf options
+      restricted = false
+      render_restricted_pdf options[:value].first, restricted
     else 
-      render_restricted_pdf options[:value]
+      restricted = true
+      render_restricted_pdf options[:value].first, restricted
     end
   end
 
-  def render_restricted_pdf pdf_csid
+  def render_restricted_pdf pdf_csid, restricted
     # render a pdf using html5 pdf viewer
-    render partial: '/shared/pdfs', locals: { csid: pdf_csid }
+    render partial: '/shared/pdfs', locals: { csid: pdf_csid, restricted: restricted }
   end
 
   def render_pdf options = {}

--- a/extras/cinefiles_pdfs.html.erb
+++ b/extras/cinefiles_pdfs.html.erb
@@ -1,4 +1,4 @@
-<%- if current_user -%>
+<%- if ((current_user && restricted == true) || (restricted == false)) -%>
   <div id="pdf" class="col-sm-12">
     <a href="https://webapps-dev.cspace.berkeley.edu/cinefiles/imageserver/blobs/<%= csid %>/content" target="new">view full size in new window</a>
     <object data="https://webapps-dev.cspace.berkeley.edu/cinefiles/imageserver/blobs/<%= csid %>/content"


### PR DESCRIPTION
…functionality by reusing _pdf partial

This adds a variable "restricted" in the application_helper method check_pdf, which is then used by logic in the _pdfs partial to display either the full document (and "open pdf in a new window") or the copyright warning block.