### PR TITLE
add global_alerts gem; add custom alert partial for cinefiles, pointi…

### DIFF
--- a/extras/cinefiles_alerts.html.erb
+++ b/extras/cinefiles_alerts.html.erb
@@ -1,0 +1,5 @@
+<% alert = GlobalAlerts::Alert.active %>
+
+<% if alert.present? %>
+    <%= alert.as_html %>
+<% end %>

--- a/extras/cinefiles_global_alerts.rb
+++ b/extras/cinefiles_global_alerts.rb
@@ -1,0 +1,14 @@
+module GlobalAlerts
+  class Engine < ::Rails::Engine
+    isolate_namespace GlobalAlerts
+
+    config.cache = nil #defaults to Rails.cache
+    config.application_name = nil
+    config_url = "https://raw.githubusercontent.com/BAM-PFA/global_alerts/main/bampfa_alerts.yaml"
+    config.url = config_url
+
+    initializer('global_alerts_default') do |app|
+      config.application_name ||= app.class.parent_name.underscore
+    end
+  end
+end

--- a/install_ucb.sh
+++ b/install_ucb.sh
@@ -110,6 +110,9 @@ cp ${extra_dir}/${tenant}_social.html.erb app/views/shared/_social.html.erb
 cp ${extra_dir}/${tenant}_blacklight.html.erb app/views/layouts/blacklight.html.erb
 cp ${extra_dir}/${tenant}_site_image.jpg public/site_image.jpg
 
+# custom global alerts (via global_alerts gem)
+cp ${extra_dir}/${tenant}_global_alerts.rb config/initializers/global_alerts.rb
+mkdir app/views/global_alerts && cp ${extra_dir}/${tenant}_global_alerts.html.erb app/views/global_alerts/_global_alerts.html.erb
 
 # to make a new splash partial for a tenant.
 # e.g. pick out 15 images to include in 4 x 4 splash partial

--- a/portal/Gemfile
+++ b/portal/Gemfile
@@ -93,3 +93,6 @@ gem 'nokogiri', '>= 1.10.4'
 gem 'devise-guests', '~> 0.6'
 gem 'blacklight-marc', '~> 6.1'
 gem 'codecov', :require => false, :group => :test
+
+# Stanford's alerts banner gem
+gem 'global_alerts'

--- a/portal/Gemfile.lock
+++ b/portal/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     devise-guests (0.7.0)
       devise
     docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.3)
     dry-configurable (0.11.5)
       concurrent-ruby (~> 1.0)
@@ -174,11 +176,27 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.0)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    global_alerts (0.0.4)
+      http
+      rails (>= 5.0, < 7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (3.6.0)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
@@ -398,6 +416,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   faraday
   font-awesome-rails
+  global_alerts
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
…ng to BAMPFA fork of Stanford's global_alerts

This is just to show a simple way to include Stanford's global_alerts gem, which uses a yaml file outside of the blacklight production server (in this example it points to https://github.com/BAM-PFA/global_alerts) to push timely alert banners. Stanford repo has documentation of using time limiters and so on to make more targeted alerts. 

This could definitely be useful for us, presumably also for PAHMA. Take a look and perhaps let's add this to future development discussions?