### PR TITLE
HMP-202: add back the stanford css for global alerts; add definition …

### DIFF
--- a/extras/cinefiles_extras.scss
+++ b/extras/cinefiles_extras.scss
@@ -174,6 +174,19 @@ h3.index_title > a {
 
 // END FONT STUFF
 
+// GLOBAL ALERTS
+$global-alert-color: rgb(89, 184, 227);
+.global-alert {
+  border: 1px solid $global-alert-color;
+  margin: 10px 0;
+  padding: 10px;
+  -moz-border-radius: 8px;
+  -webkit-border-radius: 8px;
+  border-radius: 8px;
+}
+
+// END GLOBAL ALERTS
+
 #startOverLink, .advanced-search-start-over {
   background-color: #c8c8c8;
   color: black;

--- a/extras/cinefiles_global_alerts.html.erb
+++ b/extras/cinefiles_global_alerts.html.erb
@@ -1,5 +1,6 @@
 <% alert = GlobalAlerts::Alert.active %>
-
 <% if alert.present? %>
+  <div class="global-alerts">
     <%= alert.as_html %>
+  </div>
 <% end %>


### PR DESCRIPTION
…for global-alerts css class

* this reverts the css for alerts to the default defined by the Stanford gem
* I had to add an actual definition for the `global-alert` class, which Stanford defines outside the global-alerts gem (i.e. in the independent apps they use the gem in)