### PR TITLE
HMP-243: add libv8-node (mini_racer js runtime dependency) to gemfile…

### DIFF
--- a/extras/cinefiles/app/views/shared/_social.html.erb
+++ b/extras/cinefiles/app/views/shared/_social.html.erb
@@ -3,8 +3,8 @@
 <meta name="twitter:site" content="@bampfa"/>
 <% if @document %>
   <% doc_presenter = index_presenter(@document) %>
-  <% doc_title = doc_presenter.document['doctitle_txt'] %>
-  <% if not doc_title.empty?  %>
+  <% if not doc_presenter.document['doctitle_txt'].nil?  %>
+		<% doc_title = doc_presenter.document['doctitle_txt'].join(', ') %>
     <meta property="og:title"       content="<%= doc_title %>" />
     <% unless doc_presenter.document['filmtitle_ss'].nil? %>
       <meta property="og:description"   content="<%= doc_presenter.document['filmtitle_ss'].join(', ') %>" />

--- a/portal/Gemfile
+++ b/portal/Gemfile
@@ -11,6 +11,7 @@ gem "sprockets-rails"
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', platforms: :ruby
+gem 'libv8-node', '~> 16.10.0.0'
 
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "~> 1.4"


### PR DESCRIPTION
…; fix rendering of cinefiles _social title field in Twitter card

~ looking at the rendered page source it seems like the cinefiles document title is now generated correctly. can't test the twitter card on local dev but it -looks- correct! 