### PR TITLE
HMP-286: fix cinefiles splash page content error

### DIFF
--- a/extras/cinefiles/app/views/catalog/_home_text.html.erb
+++ b/extras/cinefiles/app/views/catalog/_home_text.html.erb
@@ -145,7 +145,7 @@
                                 <p class="minor-heading">Tom Luddy</p>
                                 <p class="desc">Revisit the remarkable career of BAMPFA's first full time film curator, Tom Luddy–also a Telluride Film Festival co-founder and friend to cinema's auteur pantheon including Godard, Kurosawa, Lucas, and more. Read interviews, articles, and his BAMPFA publications like <i>Music and the movies</i> and <i>Treasures from the Eastman House</i>.</p>
                                 <p>Portrait of Tom Luddy circa 1971</p>
-                                <p><a href="/?utf8=✓&search_field=text&q=music" class="btn btn-primary">Learn more</a></p>
+                                <p><a href="/?utf8=✓&search_field=text&q=tom luddy" class="btn btn-primary">Learn more</a></p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
fixes an old link that didn't get saved into the splash page update