### PR TITLE
HMP-342: makes non-preview thumbnails resize with text

### DIFF
--- a/extras/bampfa/app/helpers/application_helper.rb
+++ b/extras/bampfa/app/helpers/application_helper.rb
@@ -106,11 +106,15 @@ module ApplicationHelper
         else
           datemade = "[No date given]"
         end
-        content_tag(:a, content_tag(:img, '',
-          src: render_csid(doc[:blob_ss][0], 'Medium'),
-          alt: render_alt_text(doc[:blob_ss][0], doc),
-          class: 'thumbclass'),
-          href: "/catalog/#{doc[:id]}") +
+        content_tag(:a,
+          content_tag(:img, '',
+            src: render_csid(doc[:blob_ss][0], 'Medium'),
+            alt: render_alt_text(doc[:blob_ss][0], doc),
+            class: 'thumbclass'
+          ),
+          href: "/catalog/#{doc[:id]}",
+          class: 'd-inline-block'
+        ) +
         content_tag(:div) do
           content_tag(:span, title, class: "gallery-caption-title") +
           content_tag(:span, "("+datemade+")", class: "gallery-caption-date") +
@@ -200,22 +204,24 @@ module ApplicationHelper
     # return a list of cards or images
     content_tag(:div) do
       options[:value].collect do |blob_csid|
-        content_tag(:a, content_tag(:img, '',
-          src: render_csid(blob_csid, 'Medium'),
-          alt: render_alt_text(blob_csid, options),
-          class: 'thumbclass'),
+        content_tag(:a,
+          content_tag(:img, '',
+            src: render_csid(blob_csid, 'Medium'),
+            alt: render_alt_text(blob_csid, options),
+            class: 'thumbclass'
+          ),
           href: "https://webapps.cspace.berkeley.edu/bampfa/imageserver/blobs/#{blob_csid}/derivatives/OriginalJpeg/content",
           # href: "https://webapps.cspace.berkeley.edu/bampfa/imageserver/blobs/#{blob_csid}/content",
           target: 'original',
           style: 'padding: 3px;',
-          class: 'hrefclass')
+          class: 'hrefclass d-inline-block')
       end.join.html_safe
     end
   end
 
   def render_alt_text blob_csid, document
     prefix = "Image of #{document[:itemclass_s] || 'BAMPFA object'}"
-    total_pages = document[:blob_ss].length
+    total_pages = document[:blob_ss] ? document[:blob_ss].length : 1
     if total_pages > 1
       page_number = "#{document[:blob_ss].find_index(blob_csid)}".to_i
       if page_number.to_s.instance_of?(String)
@@ -235,11 +241,14 @@ module ApplicationHelper
     # return a list of cards or images
     content_tag(:div) do
       options[:value].collect do |blob_csid|
-        content_tag(:a, content_tag(:img, '',
+        content_tag(:div,
+          content_tag(:img, '',
             src: render_csid(blob_csid, 'Medium'),
             alt: render_alt_text(blob_csid, options),
-            class: 'thumbclass'),
-          style: 'padding: 3px;')
+            class: 'thumbclass'
+          ),
+        class: 'd-inline-block',
+        style: 'padding: 3px;')
       end.join.html_safe
     end
   end
@@ -247,18 +256,18 @@ module ApplicationHelper
   def render_restricted_media options = {}
     # return a list of cards or images
     content_tag(:div) do
-        if current_user
-          options[:value].collect do |blob_csid|
-            content_tag(:img, '',
-                src: render_csid(blob_csid, 'Medium'),
-                alt: render_alt_text(blob_csid, options),
-                class: 'thumbclass')
-          end.join.html_safe
-        else content_tag(:img, '',
-                src: '../kuchar.jpg',
-                class: 'thumbclass',
-                alt: 'log in to view images')
-        end
+      if current_user
+        options[:value].collect do |blob_csid|
+          content_tag(:img, '',
+              src: render_csid(blob_csid, 'Medium'),
+              alt: render_alt_text(blob_csid, options),
+              class: 'thumbclass')
+        end.join.html_safe
+      else content_tag(:img, '',
+              src: '../kuchar.jpg',
+              class: 'thumbclass',
+              alt: 'log in to view images')
+      end
     end
   end
 

--- a/extras/cinefiles/app/helpers/application_helper.rb
+++ b/extras/cinefiles/app/helpers/application_helper.rb
@@ -80,15 +80,18 @@ module ApplicationHelper
     # return a list of cards or images
     content_tag(:div) do
       options[:value].collect do |blob_csid|
-        content_tag(:a, content_tag(:img, '',
-          src: render_csid(blob_csid, 'Medium'),
-          alt: '',
-          class: 'thumbclass'),
+        content_tag(:a,
+          content_tag(:img, '',
+            src: render_csid(blob_csid, 'Medium'),
+            alt: render_alt_text(blob_csid, options),
+            class: 'thumbclass'
+          ),
           href: "https://webapps.cspace.berkeley.edu/cinefiles/imageserver/blobs/#{blob_csid}/derivatives/OriginalJpeg/content",
           # href: "https://webapps.cspace.berkeley.edu/cinefiles/imageserver/blobs/#{blob_csid}/content",
           target: 'original',
           style: 'padding: 3px;',
-          class: 'hrefclass')
+          class: 'hrefclass d-inline-block'
+        )
       end.join.html_safe
     end
   end
@@ -118,10 +121,13 @@ module ApplicationHelper
     # return a list of cards or images
     content_tag(:div) do
       options[:value].collect do |blob_csid|
-        content_tag(:a, content_tag(:img, '',
+        content_tag(:div,
+          content_tag(:img, '',
             src: render_csid(blob_csid, 'Medium'),
-            alt: render_alt_text(blob_csid,options),
-            class: 'thumbclass'),
+            alt: render_alt_text(blob_csid, options),
+            class: 'thumbclass'
+          ),
+          class: 'd-inline-block',
           style: 'padding: 3px;')
       end.join.html_safe
     end
@@ -134,6 +140,7 @@ module ApplicationHelper
           options[:value].collect do |blob_csid|
             content_tag(:img, '',
                 src: render_csid(blob_csid, 'Medium'),
+                alt: render_alt_text(blob_csid, options),
                 class: 'thumbclass')
           end.join.html_safe
         else content_tag(:img, '',

--- a/portal/app/assets/stylesheets/shared.scss
+++ b/portal/app/assets/stylesheets/shared.scss
@@ -59,8 +59,14 @@ a:not(.btn):focus {
   }
 }
 .documents-list, .show-document {
-  .document .document-metadata dt {
-    min-width: 6em;
+  .document .document-metadata {
+    dd .thumbclass {
+      max-height: 12.5rem;
+      max-width: 12.5rem;
+    }
+    dt {
+      min-width: 6em;
+    }
   }
 }
 .documents-masonry .document {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/HMP-342

Also,
- added alt text to Cinefiles images where it was missing
- changed linkless media to render a div instead of an anchor tag with missing href