### PR TITLE
HMP-346: removes duplicate label from search button

### DIFF
--- a/portal/app/components/search_bar_component.html.erb
+++ b/portal/app/components/search_bar_component.html.erb
@@ -14,6 +14,7 @@
                      options_for_select(search_fields, h(@search_field)),
                      id: "#{@prefix}search_field",
                      class: "custom-select form-select search-field",
+                     autocomplete: "off"
       ) %>
     <% elsif search_fields.length == 1 %>
       <%= hidden_field_tag :search_field, search_fields.first.last %>
@@ -25,7 +26,7 @@
         placeholder: scoped_t('search.placeholder'),
         class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}",
         id: "#{@prefix}q",
-        autocomplete: autocomplete_path.present? ? "off" : "",
+        autocomplete: autocomplete_path.present? ? "off" : "on",
         autofocus: @autofocus,
         aria: { label: scoped_t('search.label') },
         data: { autocomplete_enabled: autocomplete_path.present?, autocomplete_path: autocomplete_path }
@@ -33,7 +34,7 @@
 
     <span class="input-group-append">
       <%= append %>
-      <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
+      <%= search_button || render(SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
     </span>
   </div>
 <% end %>

--- a/portal/app/components/search_button_component.rb
+++ b/portal/app/components/search_button_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SearchButtonComponent < Blacklight::SearchButtonComponent
+
+  def call
+    tag.button(class: 'btn btn-primary search-btn', type: 'submit', id: @id) do
+      tag.span(@text, class: "submit-search-text") +
+        blacklight_icon(:search, aria_hidden: true, label: false)
+    end
+  end
+end


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/HMP-346

Also fixes invalid `autocomplete` values. `"off"` means the application may be providing autocomplete functionality.  `"on"` tells the browser that it may use its own autocomplete, if available.