### PR TITLE
HMP-350: fixes search history empty rows, missing constraints

### DIFF
--- a/extras/bampfa/config/locales/blacklight.en.yml
+++ b/extras/bampfa/config/locales/blacklight.en.yml
@@ -11,6 +11,8 @@ en:
         selected:
           remove: 'Remove constraint %{label}: %{value}'
         title: 'Filter your search'
+      filters:
+        label: '%{label}'
       form:
         search:
           label: 'search for keywords'

--- a/extras/cinefiles/app/controllers/catalog_controller.rb
+++ b/extras/cinefiles/app/controllers/catalog_controller.rb
@@ -200,19 +200,19 @@ class CatalogController < ApplicationController
     #
 
     # Document record fields
-    config.add_facet_field 'doctype_s', label: 'Document: type', limit: true
-    config.add_facet_field 'doclanguage_ss', label: 'Document: language', limit: true
-    # config.add_facet_field 'pubdatescalar_s', label: 'Document: publication date', limit: true
+    config.add_facet_field 'doctype_s', label: 'Document type', limit: true
+    config.add_facet_field 'doclanguage_ss', label: 'Document language', limit: true
+    # config.add_facet_field 'pubdatescalar_s', label: 'Document publication date', limit: true
     config.add_facet_field("pubdate_i") do |field|
       field.include_in_advanced_search = false
-      field.label = 'Document: publication year'
+      field.label = 'Document publication year'
       field.range = true
       field.index_range = true
     end
-    config.add_facet_field 'author_ss', label: 'Document: author', limit: true
+    config.add_facet_field 'author_ss', label: 'Document author', limit: true
     config.add_facet_field 'director_ss', label: 'Document: director as subject', limit: true
     config.add_facet_field 'filmtitle_ss', label: 'Document: film title', limit: true
-    # config.add_facet_field 'has_ss', label: 'Document: content details', limit: true
+    # config.add_facet_field 'has_ss', label: 'Document content details', limit: true
     config.add_facet_field 'country_ss', label: 'Document: film country of production', limit: true
     config.add_facet_field 'filmyear_ss', label: 'Document: film production year', limit: true
     config.add_facet_field 'filmlanguage_ss', label: 'Document: film language', limit: true
@@ -245,11 +245,11 @@ class CatalogController < ApplicationController
     #
 
     [
-        ['doctype_txt', 'Document: type'],
-        ['source_txt', 'Document: source'],
-        ['author_txt', 'Document: author'],
-        ['doclanguage_txt', 'Document: language'],
-        ['pubdate_txt', 'Document: publication year'],
+        ['doctype_txt', 'Document type'],
+        ['source_txt', 'Document source'],
+        ['author_txt', 'Document author'],
+        ['doclanguage_txt', 'Document language'],
+        ['pubdate_txt', 'Document publication year'],
         # ['biblio_txt', 'Has bibliography'],
         # ['bx_info_txt', 'Has box info'],
         # ['cast_cr_txt', 'Has cast credits'],
@@ -265,7 +265,7 @@ class CatalogController < ApplicationController
         ['country_txt', 'Document: film country'],
         ['filmyear_txt', 'Document: film year'],
         ['filmlanguage_txt', 'Document: film language'],
-        ['docnamesubject_txt', 'Document: name subject'],
+        ['docnamesubject_txt', 'Document name subject'],
         # ['prodco_txt', 'Film production company']
         # ['genre_txt', 'Film genre(s)'],
         # the following field needs to stay 'active' for the film/document linking to work properly

--- a/extras/cinefiles/config/locales/blacklight.en.yml
+++ b/extras/cinefiles/config/locales/blacklight.en.yml
@@ -11,6 +11,8 @@ en:
         selected:
           remove: 'Remove constraint %{label}: %{value}'
         title: 'Filter your search'
+      filters:
+        label: '%{label}'
       form:
         search:
           label: 'search for keywords'

--- a/extras/common/config/locales/blacklight.en.yml
+++ b/extras/common/config/locales/blacklight.en.yml
@@ -11,6 +11,8 @@ en:
         selected:
           remove: 'Remove constraint %{label}: %{value}'
         title: 'Filter your search'
+      filters:
+        label: '%{label}'
       form:
         search:
           label: 'search for keywords'

--- a/extras/pahma/app/controllers/catalog_controller.rb
+++ b/extras/pahma/app/controllers/catalog_controller.rb
@@ -152,7 +152,7 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
 
     # UCB Customizations to use existing "catchall" field called text
-    config.add_search_field 'text', label: 'Any Fields'
+    config.add_search_field 'text', label: 'Any Field'
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.

--- a/extras/pahma/config/locales/blacklight.en.yml
+++ b/extras/pahma/config/locales/blacklight.en.yml
@@ -10,6 +10,8 @@ en:
         count: '%{number}<span class="sr-only"> objects</span>'
         selected:
           remove: 'Remove constraint %{label}: %{value}'
+      filters:
+        label: '%{label}'
       form:
         search:
           label: 'search for keywords'

--- a/portal/app/helpers/search_history_constraints_helper.rb
+++ b/portal/app/helpers/search_history_constraints_helper.rb
@@ -4,34 +4,32 @@
 # (render_search_to_s(_*))
 module SearchHistoryConstraintsHelper
   include Blacklight::SearchHistoryConstraintsHelperBehavior
+  include BlacklightAdvancedSearch::RenderConstraintsOverride
 
   # Simpler textual version of constraints, used on Search History page.
   # Theoretically can may be DRY'd up with results page render_constraints,
   # maybe even using the very same HTML with different CSS?
   # But too tricky for now, too many changes to existing CSS. TODO.
-  def render_search(params)
+  def render_search_to_s(params)
     return render(Blacklight::ConstraintsComponent.for_search_history(search_state: convert_to_search_state(params))) unless overridden_search_history_constraints_helper_methods?
 
     Deprecation.warn(Blacklight::SearchHistoryConstraintsHelperBehavior, 'Calling out to potentially overridden helpers for backwards compatibility.')
 
     Deprecation.silence(Blacklight::SearchHistoryConstraintsHelperBehavior) do
-      content_tag :dl, class: 'query row' do
-        render_search_to_s_q(params) +
-        render_search_to_s_filters(params)
+      search = content_tag :dl, class: 'query row' do
+        search_link = render_search_to_s_q(params) + render_search_to_s_filters(params)
+        if search_link.blank?
+          search_link = render_empty_search(params)
+        end
+        search_link
       end
+      tag.span('recent search: ', class: 'sr-only') + search
     end
   end
   deprecation_deprecate render_search_to_s: 'Use Blacklight::ConstraintsComponent.for_search_history instead'
 
-  ##
-  # Render the search query constraint
-  def render_search_to_s_q(params)
-    Deprecation.warn(Blacklight::SearchHistoryConstraintsHelperBehavior, '#render_search_to_s_q is deprecated without replacement')
-    return "".html_safe if params['q'].blank? && (params[:f] || params[:text] || params[:f_inclusive])
-
-    label = label_for_search_field(params[:search_field]) unless default_search_field?(params[:search_field])
-
-    render_search_to_s_element(label, render_filter_value(params['q']))
+  def render_empty_search(params)
+    render_search_to_s_element(nil, nil)
   end
 
   # value can be Array, in which case elements are joined with
@@ -39,14 +37,16 @@ module SearchHistoryConstraintsHelper
   # html for value. key with escape_key if needed.
   def render_search_to_s_element(key, value, _options = {})
     Deprecation.warn(Blacklight::SearchHistoryConstraintsHelperBehavior, '#render_search_to_s_element is deprecated without replacement')
+    if value.blank?
+      value = tag.span('blank', class: 'filter-value sr-only')
+    end
     render_filter_name(key) + tag.dd(value, class: 'filter-values col-9 col-lg-10 mb-0')
   end
 
   # Render the name of the facet
   def render_filter_name name
     Deprecation.warn(Blacklight::SearchHistoryConstraintsHelperBehavior, '#render_filter_name is deprecated without replacement')
-
-    tag.dt(t('blacklight.search.filters.label', label: name || 'Any Fields'), class: 'filter-name col-3 col-lg-2')
+    tag.dt(t('blacklight.search.filters.label', label: name || 'Any Field'), class: 'filter-name col-3 col-lg-2')
   end
 
   ##

--- a/portal/app/helpers/url_helper.rb
+++ b/portal/app/helpers/url_helper.rb
@@ -5,9 +5,10 @@ module UrlHelper
   def link_to_previous_search(params, index, count)
     Deprecation.silence(SearchHistoryConstraintsHelper) do
       link_to(
-        render_search(params),
+        render_search_to_s(params),
         search_action_path(params),
-        aria: { label: "recent search #{index + 1} of #{count}" }
+        class: 'd-block',
+        aria: { description: "recent search #{index + 1} of #{count}" }
       )
     end
   end

--- a/portal/config/locales/blacklight.en.yml
+++ b/portal/config/locales/blacklight.en.yml
@@ -1,3 +1,48 @@
 en:
   blacklight:
-    application_name: 'Blacklight'
+    # this is required to provide screen readers with a label for the Advanced Search boolean operators AND/ANY
+    advanced_search:
+      op:
+        label: 'search operator'
+    application_name: 'CineFiles'
+    search:
+      facets:
+        count: '%{number}<span class="sr-only"> objects</span>'
+        selected:
+          remove: 'Remove constraint %{label}: %{value}'
+        title: 'Filter your search'
+      filters:
+        label: '%{label}'
+      form:
+        search:
+          label: 'search for keywords'
+          placeholder: 'Enter a few keywords here to get started...'
+      start_over: 'Reset'
+      pagination_info:
+        no_items_found: No %{entry_name} found
+        pages:
+          one: '<strong>%{start_num}</strong> <span aria-hidden="true">-</span><span class="sr-only">to</span> <strong>%{end_num}</strong> of <strong>%{total_num}</strong>'
+          other: '<strong>%{start_num}</strong> <span aria-hidden="true">-</span><span class="sr-only">to</span> <strong>%{end_num}</strong> of <strong>%{total_num}</strong>'
+        single_item_found: "<strong>1</strong> %{entry_name} found"
+      per_page:
+        aria_label: 'Results'
+      view:
+        gallery: "Gallery view"
+        list: "List view"
+        slideshow: "Slideshow view"
+        masonry: "Masonry view"
+  blacklight_gallery:
+    catalog:
+      grid_slideshow:
+        missing_image: '<span class="sr-only">Image </span>Missing<span class="sr-only">: %{alt_text}</span>'
+  views:
+    pagination:
+      aria:
+        current_page: 'Page %{page}'
+      first: '<span aria-hidden="true">&laquo;</span> First <span class="sr-only">page</span>'
+      last: 'Last <span class="sr-only">page</span> <span aria-hidden="true">&raquo;</span>'
+      previous: '<span aria-hidden="true">&laquo;</span> Previous <span class="sr-only">page</span>'
+      next: 'Next <span class="sr-only">page</span> <span aria-hidden="true">&raquo;</span>'
+    pagination_compact:
+      next: 'Next <span class="sr-only">page</span><span aria-hidden="true">&raquo;</span>'
+      previous: '<span aria-hidden="true">&laquo;</span> Previous <span class="sr-only">page</span>'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/HMP-350

I also removed some colons from labels because there were just too many. For example, 'Document: type: ...'. I kept the ones that seem important for semantics.