### PR TITLE
HMP-322: adds museum ID to bookmark labels for pahma, bampfa

### DIFF
--- a/extras/bampfa/app/helpers/application_helper.rb
+++ b/extras/bampfa/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def bookmark_control_label document, counter, total
-    label = "#{document['objname_s']}"
+    label = "#{document['title_s']}, accession number #{document['idnumber_s']}"
     if counter && counter.to_i > 0
       label += ". Search result #{counter}"
       if total && total.to_i > 0

--- a/extras/cinefiles/app/helpers/application_helper.rb
+++ b/extras/cinefiles/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def bookmark_control_label document, counter, total
-    label = document['common_doctype_s'] || 'object'
+    label = "#{document['common_doctype_s'] || 'object'}"
     if document['common_title_ss']
       label += " titled #{document['common_title_ss'].join(', ')}"
     end

--- a/extras/pahma/app/helpers/application_helper.rb
+++ b/extras/pahma/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def bookmark_control_label document, counter, total
-    label = "#{document['objname_s']}"
+    label = "#{document['objname_s']}, museum number #{document['objmusno_s']}"
     if counter && counter.to_i > 0
       label += ". Search result #{counter}"
       if total && total.to_i > 0

--- a/portal/app/assets/stylesheets/shared.scss
+++ b/portal/app/assets/stylesheets/shared.scss
@@ -52,15 +52,18 @@ a:not(.btn):not(.nav-link):focus {
   width: 100%;
 }
 .documents-gallery, .documents-masonry {
-  .document .document-counter {
-    clip: rect(0, 0, 0, 0);
-    display: block;
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
+  .document .documentHeader .document-title-heading {
+    flex: 0 0 100%;
+    .document-counter {
+      clip: rect(0, 0, 0, 0);
+      display: block;
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+    }
   }
 }
 .documents-gallery .document {
@@ -76,10 +79,9 @@ a:not(.btn):not(.nav-link):focus {
 .documents-gallery .document .documentHeader,
 .documents-list .document .documentHeader {
   align-items: baseline;
-}
-.documents-gallery .document .index-document-functions,
-.documents-list .document .index-document-functions {
-  margin-bottom: 0.5rem;
+  .index-document-functions {
+    margin-bottom: 0.5rem;
+  }
 }
 .documents-list .document {
   .document-thumbnail {
@@ -98,6 +100,10 @@ a:not(.btn):not(.nav-link):focus {
   }
   .document-title-heading {
     align-content: center;
+    display: flex;
+    .document-counter {
+      margin-right: 0.5rem;
+    }
   }
 }
 .documents-list, .show-document {

--- a/portal/app/components/document/bookmark_component.rb
+++ b/portal/app/components/document/bookmark_component.rb
@@ -2,7 +2,7 @@
 
 module Document
   # Render a bookmark widget to bookmark / unbookmark a document
-  class BookmarkComponent < Blacklight::Component
+  class BookmarkComponent < Blacklight::Document::BookmarkComponent
     # @param [Blacklight::Document] document
     # @param [Boolean] checked
     # @param [Object] bookmark_path the rails route to use for bookmarks
@@ -12,16 +12,6 @@ module Document
       @bookmark_path = bookmark_path
       @counter = counter
       @total = total
-    end
-
-    def bookmarked?
-      return @checked unless @checked.nil?
-
-      helpers.bookmarked? @document
-    end
-
-    def bookmark_path
-      @bookmark_path || helpers.bookmark_path(@document)
     end
 
     def label


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/HMP-322

In gallery and masonry views, the `document_counter` isn't readily available to the bookmark component. Adding the museum ID ensures unique labels and provides more context.