### PR TITLE
HMP-383: makes link targets focusable; removes multiple header landmarks

### DIFF
--- a/extras/bampfa/app/assets/stylesheets/extras.scss
+++ b/extras/bampfa/app/assets/stylesheets/extras.scss
@@ -12,7 +12,7 @@
   color: black;
   font-weight: bold;
   text-decoration: none;
-  &:hover {
+  &:hover:not([aria-disabled]) {
     text-decoration: underline;
   }
 }

--- a/extras/pahma/app/assets/stylesheets/extras.scss
+++ b/extras/pahma/app/assets/stylesheets/extras.scss
@@ -51,7 +51,7 @@
 .site-footer a {
   color: white;
 }
-.site-footer a:hover {
+.site-footer a:hover:not([aria-disabled]) {
   color: #1BDBA6;
   text-decoration: underline;
 }
@@ -66,7 +66,7 @@
   margin-top: 10px;
   max-width: 180px;
 }
-.site-footer .copyright a {
+.site-footer .copyright a:not([aria-disabled]) {
   text-decoration: underline;
 }
 .site-footer .footer-logo {
@@ -123,7 +123,7 @@
     padding: 0 2px;
     white-space: nowrap;
     width: 100%;
-    &:hover {
+    &:hover:not([aria-disabled]) {
       text-decoration: underline;
     }
   }

--- a/portal/app/assets/stylesheets/shared.scss
+++ b/portal/app/assets/stylesheets/shared.scss
@@ -308,7 +308,7 @@ a:not(.btn):not(.nav-link):focus {
 .search-widgets .view-type .blacklight-icons svg {
   display: inline-block;
 }
-.site-footer a:hover {
+.site-footer a:hover:not([aria-disabled]) {
   text-decoration: underline;
 }
 .site-footer ul {
@@ -418,7 +418,7 @@ label.toggle-bookmark {
     margin-right: 0.5rem;
   }
 }
-p a:not(.btn) {
+p a:not(.btn):not([aria-disabled]) {
   font-weight: bold;
   text-decoration: underline dotted;
   &:hover {

--- a/portal/app/components/blacklight/document_title_component.html.erb
+++ b/portal/app/components/blacklight/document_title_component.html.erb
@@ -1,0 +1,17 @@
+<div class="documentHeader row">
+  <%= content_tag @as, class: @classes do %>
+    <% before_titles.each do |t| %>
+      <%= t %>
+    <% end %>
+
+    <%= counter -%><%= title -%>
+
+    <% after_titles.each do |t| %>
+      <%= t %>
+    <% end %>
+  <% end %>
+
+  <% actions.each do |action| %>
+    <%= action %>
+  <% end %>
+</div>

--- a/portal/app/components/blacklight/document_title_component.rb
+++ b/portal/app/components/blacklight/document_title_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class DocumentTitleComponent < Blacklight::Component
+    renders_many :before_titles
+    renders_many :after_titles
+    renders_many :actions
+
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(title = nil, document: nil, presenter: nil, as: :h3, counter: nil, classes: 'index_title document-title-heading col', link_to_document: true, document_component: nil)
+      raise ArgumentError, 'missing keyword: :document or :presenter' if presenter.nil? && document.nil?
+
+      @title = title
+      @document = document
+      @presenter = presenter
+      @as = as || :h3
+      @counter = counter
+      @classes = classes
+      @link_to_document = link_to_document
+      @document_component = document_component
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    # Content for the document title area; should be an inline element
+    def title
+      if @link_to_document
+        helpers.link_to_document presenter.document, @title.presence || content.presence, counter: @counter, itemprop: 'name'
+      else
+        content_tag('span', @title.presence || content.presence || presenter.heading, itemprop: 'name')
+      end
+    end
+
+    # Content for the document actions area
+    def actions
+      if block_given?
+        @has_actions_slot = true
+        return super
+      end
+
+      (@has_actions_slot && get_slot(:actions)) ||
+        ([@document_component&.actions] if @document_component&.actions.present?) ||
+        [helpers.render_index_doc_actions(presenter.document, wrapping_class: 'index-document-functions col-sm-3 col-lg-2')]
+    end
+
+    def counter
+      return unless @counter
+
+      content_tag :span, class: 'document-counter' do
+        t('blacklight.search.documents.counter', counter: @counter)
+      end
+    end
+
+    private
+
+    def presenter
+      @presenter ||= helpers.document_presenter(@document)
+    end
+  end
+end

--- a/portal/app/views/kaminari/blacklight_compact/_paginator.html.erb
+++ b/portal/app/views/kaminari/blacklight_compact/_paginator.html.erb
@@ -1,0 +1,35 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+
+   Paginator now using the Bootstrap paginator class
+
+   page_entries_info is passed into the paginate call, e.g. :
+
+   > paginate collection, :page_entries_info => page_entries_info(collection), :theme => :blacklight_compact
+
+   As of Kaminari 0.15, this paginator doesn't have access to the original collection/scope, so it can't render the page entries info directly.
+-%>
+<% if total_pages > 1 -%>
+  <%# #render checks if total_pages > 1, so we can't put our fallback
+  in here .. -%>
+  <%= paginator.render do -%>
+    <div class="page-links">
+      <%= prev_page_tag %><span role="separator"> | </span>
+      <span class="page-entries">
+        <%= page_entries_info %>
+      </span><span role="separator"> | </span>
+      <%= next_page_tag %>
+    </div>
+  <% end -%>
+<% else -%>
+    <div class="page-links">
+      <span class="page-entries">
+        <%= page_entries_info %>
+      </span>
+    </div>
+<% end -%>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/HMP-383

A few more link targets needed to be focusable.

Also, 
- Ensures only one <header> landmark per page
- Removes underline style from disabled links (e.g. when modal open)
- Adds separator role to special chars ("|") in pagination