### PR TITLE
HMP-428: prevents modal_path error on advanced search page

### DIFF
--- a/extras/cinefiles/app/components/blacklight/facet_field_list_component.html.erb
+++ b/extras/cinefiles/app/components/blacklight/facet_field_list_component.html.erb
@@ -15,7 +15,7 @@
       <%= render_facet_limit_list @facet_field.paginator, @facet_field.key %>
     </ul>
     <%# backwards compatibility, ugh %>
-    <% if @layout == Blacklight::FacetFieldNoLayoutComponent && !@facet_field.in_modal? && @facet_field.modal_path %>
+    <% if @layout == Blacklight::FacetFieldNoLayoutComponent && !@facet_field.in_modal? && !@view_context.is_advanced_search? && @facet_field.modal_path %>
       <div class="more_facets">
         <%= link_to t("more_#{@facet_field.key}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: @facet_field.label),
           @facet_field.modal_path,

--- a/extras/common/app/components/blacklight/facet_field_list_component.html.erb
+++ b/extras/common/app/components/blacklight/facet_field_list_component.html.erb
@@ -8,7 +8,7 @@
       <%= render_facet_limit_list @facet_field.paginator, @facet_field.key %>
     </ul>
     <%# backwards compatibility, ugh %>
-    <% if @layout == Blacklight::FacetFieldNoLayoutComponent && !@facet_field.in_modal? && @facet_field.modal_path %>
+    <% if @layout == Blacklight::FacetFieldNoLayoutComponent && !@facet_field.in_modal? && !@view_context.is_advanced_search? && @facet_field.modal_path %>
       <div class="more_facets">
         <%= link_to t("more_#{@facet_field.key}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: @facet_field.label),
           @facet_field.modal_path,

--- a/extras/pahma/app/components/blacklight/facet_field_list_component.html.erb
+++ b/extras/pahma/app/components/blacklight/facet_field_list_component.html.erb
@@ -17,7 +17,7 @@
       <%= render_facet_limit_list @facet_field.paginator, @facet_field.key %>
     </ul>
     <%# backwards compatibility, ugh %>
-    <% if @layout == Blacklight::FacetFieldNoLayoutComponent && !@facet_field.in_modal? && @facet_field.modal_path %>
+    <% if @layout == Blacklight::FacetFieldNoLayoutComponent && !@facet_field.in_modal? && !@view_context.is_advanced_search? && @facet_field.modal_path %>
       <div class="more_facets">
         <%= link_to t("more_#{@facet_field.key}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: @facet_field.label),
           @facet_field.modal_path,


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/HMP-428